### PR TITLE
🚀 chore(npm-publish-packages.yml): remove unnecessary --access public…

### DIFF
--- a/.github/workflows/npm-publish-packages.yml
+++ b/.github/workflows/npm-publish-packages.yml
@@ -29,6 +29,6 @@ jobs:
         with:
           node-version: 16
       - run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
-      - run: yarn publish --access public
+      - run: yarn publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/npm-publish-packages.yml
+++ b/.github/workflows/npm-publish-packages.yml
@@ -30,5 +30,3 @@ jobs:
           node-version: 16
       - run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
       - run: yarn publish
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
… flag from yarn publish command

The --access public flag is not necessary when publishing packages to npm, as the default access level is already public. Removing this flag simplifies the command and improves readability.