### PR TITLE
🔧 chore(package.json): update build script in package.json to include…

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "sideEffects": false,
   "scripts": {
     "start": "rollup --config --watch --bundleConfigAsCjs",
-    "build": "rollup -c --bundleConfigAsCjs"
+    "build": "rollup -c --prod --bundleConfigAsCjs"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,42 +7,50 @@ import peerDepsExternal from "rollup-plugin-peer-deps-external";
 import serve from 'rollup-plugin-serve'
 import scss from 'rollup-plugin-scss'
 import livereload from 'rollup-plugin-livereload'
+
 const packageJson = require("./package.json");
 
-export default [
-    {
-        input: "src/lib/canvas.index.ts",
-        output: [
-            {
-                file: packageJson.main,
-                format: "iife",
-                sourcemap: true,
-            },
-            {
-                file: packageJson.module,
-                format: "esm",
-                sourcemap: true,
-            },
-        ],
-        plugins: [
-            scss(),
-            peerDepsExternal(),
-            resolve(),
-            commonjs(),
-            typescript({tsconfig: "./tsconfig.json"}),
-            terser(),
-            livereload(),
-            serve({
-                openPage: '/index.html',
-                contentBase: ['dist', 'examples','src'],
-                port: 3002,
-            })
-        ],
-        external: [],
-    },
-    {
-        input: "src/lib/canvas.index.ts",
-        output: [{file: "dist/types.d.ts", format: "es"}],
-        plugins: [scss(), dts.default()],
-    },
-];
+export default commandLineArgs => {
+    console.log('cmd', commandLineArgs)
+    let config = [
+        {
+            input: "src/lib/canvas.index.ts",
+            output: [
+                {
+                    file: packageJson.main,
+                    format: "iife",
+                    sourcemap: true,
+                },
+                {
+                    file: packageJson.module,
+                    format: "esm",
+                    sourcemap: true,
+                },
+            ],
+            plugins: [
+                scss(),
+                peerDepsExternal(),
+                resolve(),
+                commonjs(),
+                typescript({tsconfig: "./tsconfig.json"}),
+                terser()
+            ],
+            external: [],
+        },
+        {
+            input: "src/lib/canvas.index.ts",
+            output: [{file: "dist/types.d.ts", format: "es"}],
+            plugins: [scss(), dts.default()],
+        },
+    ];
+    console.log('commandLineArgs.prod', commandLineArgs.prod)
+    if (!commandLineArgs.prod) {
+        config[0].plugins.push(livereload())
+        config[0].plugins.push(serve({
+            openPage: '/index.html',
+            contentBase: ['dist', 'examples', 'src'],
+            port: 3002,
+        }))
+    }
+    return config;
+}


### PR DESCRIPTION
… --prod flag for rollup command

🔧 chore(rollup.config.js): modify rollup.config.js to conditionally add livereload and serve plugins based on command line argument 'prod'