### PR TITLE
chore(publish.yml): enable update changelog step and remove unused steps

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,22 +60,12 @@ jobs:
           RELEASE_TYPE: ${{ github.event.inputs.release-type }}
 
       # Update changelog unreleased section with new version
-#      - name: Update changelog
-#        uses: superfaceai/release-changelog-action@v1
-#        with:
-#          path-to-changelog: CHANGELOG.md
-#          version: ${{ env.NEW_VERSION }}
-#          operation: release
-      - name: Conventional commits check
-        uses: oknozor/cocogitto-action@v3
+      - name: Update changelog
+        uses: superfaceai/release-changelog-action@v1
         with:
-          release: true
-          check-latest-tag-only: true
-          git-user: 'Ali Sait Teke'
-          git-user-email: 'alisaitteke@gmail.com'
-
-      - name: Print version
-        run: "echo '${{ steps.release.outputs.version }}'"
+          path-to-changelog: CHANGELOG.md
+          version: ${{ env.NEW_VERSION }}
+          operation: release
 
       # Commit changes
       - name: Commit CHANGELOG.md and package.json changes and create tag


### PR DESCRIPTION
The update changelog step was commented out in the workflow file. This commit enables the step and removes the unused steps related to conventional commits check and printing the version. This change ensures that the changelog is updated with the new version and the changes are committed.