### PR TITLE
chore(publish.yml): comment out changelog update and commit steps

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,20 +58,20 @@ jobs:
           RELEASE_TYPE: ${{ github.event.inputs.release-type }}
 
       # Update changelog unreleased section with new version
-      - name: Update changelog
-        uses: superfaceai/release-changelog-action@v1
-        with:
-          path-to-changelog: CHANGELOG.md
-          version: ${{ env.NEW_VERSION }}
-          operation: release
-
-      # Commit changes
-      - name: Commit CHANGELOG.md and package.json changes and create tag
-        run: |
-          git add "package.json"
-          git add "CHANGELOG.md"
-          git commit -m "chore: release ${{ env.NEW_VERSION }}"
-          git tag ${{ env.NEW_VERSION }}
+#      - name: Update changelog
+#        uses: superfaceai/release-changelog-action@v1
+#        with:
+#          path-to-changelog: CHANGELOG.md
+#          version: ${{ env.NEW_VERSION }}
+#          operation: release
+#
+#      # Commit changes
+#      - name: Commit CHANGELOG.md and package.json changes and create tag
+#        run: |
+#          git add "package.json"
+#          git add "CHANGELOG.md"
+#          git commit -m "chore(release) ${{ env.NEW_VERSION }}"
+#          git tag ${{ env.NEW_VERSION }}
 
       # Publish version to public repository
       - name: Publish


### PR DESCRIPTION
The changelog update and commit steps are commented out to prevent unnecessary commits and tags during the publish workflow. This is done to avoid cluttering the repository history with intermediate commits and tags.